### PR TITLE
feat!: upgrade to prisma v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
   "author": "Cerebrum <hello@cerebrum.com> (https://cerebrum.com)",
   "license": "MIT",
   "devDependencies": {
-    "@prisma/client": "^4.0.0",
+    "@prisma/client": "^5.0.0",
     "@types/jest": "^29.2.6",
     "@types/lodash": "^4.14.191",
     "@types/uuid": "^9.0.0",
     "jest": "^29.3.1",
-    "prisma": "^4.9.0",
+    "prisma": "^5.0.0",
     "rome": "^11.0.0",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.4",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@prisma/client": "^4.0.0",
-    "prisma": "^4.9.0"
+    "@prisma/client": "^5.0.0",
+    "prisma": "^5.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from "@prisma/client";
+import { RuntimeDataModel } from "@prisma/client/runtime/library";
 
 const castArray = <T>(value: T | T[]): T[] => {
 	if (Array.isArray(value)) {
@@ -10,12 +11,13 @@ const castArray = <T>(value: T | T[]): T[] => {
 // Creates an object indicating the unique fields for each model
 const getUniqueFieldData = (client: PrismaClient) => {
 	const uniqueFields: { [model: string]: { [field: string]: boolean } } = {};
-	for (const model of (client as any)._baseDmmf.datamodel.models) {
-		if (!uniqueFields[model.name]) {
-			uniqueFields[model.name] = {};
+	const runtimeDataModel = (client as any)._runtimeDataModel as RuntimeDataModel;
+	for (const key in runtimeDataModel.models) {
+		if (!uniqueFields[key]) {
+			uniqueFields[key] = {};
 		}
-		for (const field of model.fields) {
-			uniqueFields[model.name][field.name] = field.isId || field.isUnique;
+		for (const field of runtimeDataModel.models[key].fields) {
+			uniqueFields[key][field.name] = field.isId || field.isUnique;
 		}
 	}
 


### PR DESCRIPTION
Not much was needed to make this update, as the dmmf is now found under the private property `_runtimeDataModel`. This property has available types and is even checked in a unit test in the prisma library.

BREAKING CHANGE: requires Prisma v5